### PR TITLE
meson: add install option for preprocessed dts file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,9 @@ devicetree_dtsd = custom_target('devicetree-dtsd',
         '-MT', '@INPUT@',
         '-MMD',  '-MF', '@DEPFILE@',
         '-o', '@OUTPUT@'],
+    install: get_option('install'),
+    install_tag: 'devel',
+    install_dir: get_option('datadir'),
 )
 
 devicetree_dts = custom_target('devicetree-dts',

--- a/meson.options
+++ b/meson.options
@@ -18,3 +18,4 @@ option('dts', type: 'string', description: 'Top level DTS file', yield: true)
 option('dts-include-dirs', type: 'array', yield: true,
        description: 'Directories to add to resolution path for dtsi inclusion')
 option('dts-bindings-dir', type: 'string', description: 'DTS validation schema directory')
+option('install', type: 'boolean', description: 'Install preprocessed dts file', value: false)


### PR DESCRIPTION
If set to true, preprocessed dts file is installed to datadir.
This is tagged with  `devel`.
It is up to the top level project to set this option.
Usually set to true by the kernel only (and installed to outpost SDK).