### PR TITLE
st,stm32u5: add dma2d device node

### DIFF
--- a/dts/manufacturer/st/u5/stm32u575.dtsi
+++ b/dts/manufacturer/st/u5/stm32u575.dtsi
@@ -24,6 +24,13 @@
 			phys = <&otgfs_phy>;
 			status = "disabled";
 		};
+
+		dma2d: gpu@4002b000 {
+			compatible = "st,stm32-dma2d";
+			reg = <0x4002b000 0xC00>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
+			status = "disabled";
+		};
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/manufacturer/st/u5/stm32u595.dtsi
+++ b/dts/manufacturer/st/u5/stm32u595.dtsi
@@ -56,5 +56,12 @@
 			interrupt-names = "event", "error";
 			status = "disabled";
 		};
+
+		dma2d: gpu@4002b000 {
+			compatible = "st,stm32-dma2d";
+			reg = <0x4002b000 0xC00>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
This peripheal is present on stm32u575/585/59X/5AX/5FX/5GX (i.e. not stm32u53/545)