### PR TITLE
meson: add required version check for dts2src program.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ dtc = find_program('dtc')
 #      This is disabled until dtschema bump
 # dt_validate = find_program('dt-validate')
 
-dts2src = find_program('dts2src')
+dts2src = find_program('dts2src', version: '>= 0.3.0')
 
 # dts input file search path order:
 # - Path is absolute

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 swig
-dts-utils>=0.2.0
+dts-utils>=0.3.0
 
 # XXX: re-enable this once there arn't using deprecated jsconschema anymore
 # dtschema


### PR DESCRIPTION
Version 0.3.0 is the minimal requirement for sentry kernel to build.