### PR TITLE
st,wb: add syscfg device node

### DIFF
--- a/dts/manufacturer/st/wb/stm32wb.dtsi
+++ b/dts/manufacturer/st/wb/stm32wb.dtsi
@@ -156,7 +156,10 @@
 				max-erase-time = <25>;
 			};
 		};
-
+		syscfg: system-config@40010000 {
+			compatible = "st,stm32-syscfg", "syscon";
+			reg = <0x40010000 0x200>;
+		};
 		rcc: rcc@58000000 {
 			compatible = "st,stm32wb-rcc";
 			#clock-cells = <2>;


### PR DESCRIPTION
add missing syscfg device node for wtm32wb subfamily.